### PR TITLE
docs: Minor touches to main homepage

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -4,21 +4,21 @@ description: Get started building your docs site with Starlight.
 template: splash
 hero:
   title: The <strong class="text-highlight-500 dark:text-highlight-200">easiest</strong> way to build your own desktop Linux images.
-  tagline: The BlueBuild project creates accessible tools for you to configure, build, and create custom images of atomic Fedora distributions.
+  tagline: The BlueBuild project creates accessible tools for you to configure, build & create custom images of atomic Fedora distributions.
   actions:
     - text: Let's get started!
       link: /learn/getting-started/
       # "<svg" is a required workaround, see Hero.astro
       icon: "<svg material-symbols:book-5"
       variant: primary
-    - text: Github
+    - text: GitHub
       link: https://github.com/blue-build/
       icon: "<svg ic:round-launch"
       variant: minimal
 banner:
   content: | 
     We're the new home of the old custom image tooling from <a href="https://universal-blue.org/">Universal Blue</a>.
-    This website is very new and a lot of content is missing. 
+    This website is very new & a lot of content is missing. 
     <a href="https://github.com/blue-build/">Contribute!</a>
 ---
 
@@ -34,17 +34,17 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		The modular build system can easily be extended by just writing a shell script.
     Modules you create can be added into the official BlueBuild repository or your own for the community to take advantage of.
 	</Card>
-	<Card title="Based on standards" icon="puzzle">
-		The format of your OS images is the familiar OCI image format, famously used by Docker and Podman.
+	<Card title="Based on solid standards" icon="puzzle">
+		The format of your OS images is the familiar OCI image format, famously used by Docker & Podman.
     With Fedora's Native Container support, it becomes possible to boot natively into a OCI compatible image.
 	</Card>
-	<Card title="Free and open source" icon="open-book">
-		BlueBuild is an open source project built by the community for the community.
-    Feel free to peek at and tinker with the source code!
-    GitHub also provides CI/CD and a container registry for free, though other providers are supported as well.
+	<Card title="Free & open-source" icon="open-book">
+		BlueBuild is an open-source project built by the community for the community.
+    Feel free to peek at & tinker with the source code!
+    GitHub also provides CI/CD & a container registry for free, though other providers are supported as well.
 	</Card>
-  <Card title="Effortless stability" icon="information">
-		With your custom images being based on stable atomic distributions, your setup will be rock solid.
+  <Card title="Effortless top-notch reliability" icon="information">
+		With your custom images being based on reliable atomic distributions, your setup will be rock solid.
     As all errors related to customizing your environment happen during the build process in the cloud, it's way harder to end up with a bricked system.
 	</Card>
 </CardGrid>
@@ -53,5 +53,5 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ### Is this site ready?
 
-Not at all! Basically none of the documentation pages have content, and work hasn't even started on the tooling part.
+Not at all! Basically none of the documentation pages have content, & work hasn't even started on the tooling part.
 But you can help us in the [GitHub](https://github.com/blue-build/website) repo!

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -34,7 +34,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		The modular build system can easily be extended by just writing a shell script.
     Modules you create can be added into the official BlueBuild repository or your own for the community to take advantage of.
 	</Card>
-	<Card title="Based on solid standards" icon="puzzle">
+	<Card title="Based on well-known standards" icon="puzzle">
 		The format of your OS images is the familiar OCI image format, famously used by Docker & Podman.
     With Fedora's Native Container support, it becomes possible to boot natively into a OCI compatible image.
 	</Card>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -43,7 +43,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     Feel free to peek at & tinker with the source code!
     GitHub also provides CI/CD & a container registry for free, though other providers are supported as well.
 	</Card>
-  <Card title="Effortless top-notch reliability" icon="information">
+  <Card title="Effortless reliability" icon="information">
 		With your custom images being based on reliable atomic distributions, your setup will be rock solid.
     As all errors related to customizing your environment happen during the build process in the cloud, it's way harder to end up with a bricked system.
 	</Card>


### PR DESCRIPTION
Use `&` instead of `and`

`open-source` instead of `open source`

Use more accurate term
`reliability` instead of `stability`

Indicate that standards are solid as a base.

`GitHub` instead of `Github` in some places.