### PR TITLE
docs: Add documentation for stages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -79,6 +79,10 @@ export default defineConfig({
                             link: "/reference/module/",
                         },
                         {
+                            label: "Stages",
+                            link: "/reference/stages/",
+                        },
+                        {
                             label: "Modules",
                             autogenerate: {
                                 directory: "reference/modules",

--- a/src/content/docs/reference/module.mdx
+++ b/src/content/docs/reference/module.mdx
@@ -11,15 +11,19 @@ Modules themselves differ on what configuration options they use and require, an
 
 ### `type:`
 
-The name of the module to run.
+The name of the module to run. This corresponds to the name of the directory as well as the script's name in the module's directory. For example, using `test` would call the script in `$MODULE_DIRECTORY/test/test.sh`.
 
 ### `source:` (optional)
-
-The URL of the module repository (an OCI image) to pull the module from. If left unspecified, the source use is a hybrid the default module repository at `ghcr.io/blue-build/modules` and the custom modules in the local `modules/` directory, where custom modules overwrite the default modules.
 
 :::caution
 A module can execute arbitrary code both in the image build and consequently on your booted system, so make sure you trust the source you specify.
 :::
+
+The URL of the module repository (an OCI image) to pull the module from. If left unspecified, the source use is a hybrid the default module repository at `ghcr.io/blue-build/modules` and the custom modules in the local `modules/` directory, where custom modules overwrite the default modules.
+
+### `no-cache:` (optional)
+
+When set to `true`, the module is run regardless if previous layers in the build have been cached. This is useful in [stages](/reference/stages) where the goal is to build the latest version of a program from a git repository. Otherwise, the module wouldn't run again unless previous layers were also re-ran.
 
 ## How modules are launched
 

--- a/src/content/docs/reference/recipe.mdx
+++ b/src/content/docs/reference/recipe.mdx
@@ -71,7 +71,7 @@ A list of [stages](/references/stages/) that is executed outside of the final im
 stages:
   - name: bluebuild
     from: rust
-    modules:
+    modules: # same as the top-level modules key, but executed in the custom stage
       - type: script
         no-cache: true
         snippets:

--- a/src/content/docs/reference/recipe.mdx
+++ b/src/content/docs/reference/recipe.mdx
@@ -27,6 +27,18 @@ The image description. Published to GHCR in the image metadata.
 description: This is my personal OS image.
 ```
 
+### `alt-tags:`
+
+Allows setting custom tags on the recipe's final image. Adding tags to this property will override the `latest` and timestamp tags.
+
+#### Example:
+
+```yaml
+alt-tags:
+  - gts
+  - stable
+```
+
 ### `base-image:`
 
 The [OCI](https://opencontainers.org/) image to base your custom image on. Only atomic Fedora images and those based on them are officially supported. Universal Blue is recommended. A list of uBlue images can be found on the [uBlue website](https://universal-blue.org/images/). BlueBuild-built images can be used as well.
@@ -49,6 +61,23 @@ The tag of the base image to build on. Used to select a version explicitly (`40`
 image-version: 40
 ```
 
+### `stages:`
+
+A list of [stages](/references/stages/) that is executed outside of the final image. This is useful for compiling programs from source without polluting the final bootable image.
+
+#### Example:
+
+```yaml
+stages:
+  - name: bluebuild
+    from: rust
+    modules:
+      - type: script
+        no-cache: true
+        snippets:
+          - cargo install --locked --all-features blue-build
+```
+
 ### `modules:`
 
 A list of [modules](/reference/module/) that is executed in order. Multiple of the same module can be included.
@@ -60,9 +89,9 @@ Each item in this list should have at least a `type:` or be specified to be incl
 ```yaml
 # recipes/recipe.yml
 modules:
-    - type: rpm-ostree
-      # rest of the module config...
-    - from-file: common-packages.yml
+  - type: rpm-ostree
+    # rest of the module config...
+  - from-file: common-packages.yml
 ```
 
 The included file can have one or multiple modules:
@@ -78,8 +107,8 @@ type: rpm-ostree
 # recipes/common-packages.yml
 # multiple modules
 modules:
-    - type: script
-      # rest of the module config...
-    - type: rpm-ostree
-      # rest of the module config...
+  - type: script
+    # rest of the module config...
+  - type: rpm-ostree
+    # rest of the module config...
 ```

--- a/src/content/docs/reference/recipe.mdx
+++ b/src/content/docs/reference/recipe.mdx
@@ -70,7 +70,7 @@ A list of [stages](/references/stages/) that are executed before the build of th
 ```yaml
 stages:
   - name: bluebuild
-    from: rust
+    from: rust:1.77
     modules: # same as the top-level modules key, but executed in the custom stage
       - type: script
         no-cache: true

--- a/src/content/docs/reference/recipe.mdx
+++ b/src/content/docs/reference/recipe.mdx
@@ -27,7 +27,7 @@ The image description. Published to GHCR in the image metadata.
 description: This is my personal OS image.
 ```
 
-### `alt-tags:`
+### `alt-tags:` (optional)
 
 Allows setting custom tags on the recipe's final image. Adding tags to this property will override the `latest` and timestamp tags.
 
@@ -61,7 +61,7 @@ The tag of the base image to build on. Used to select a version explicitly (`40`
 image-version: 40
 ```
 
-### `stages:`
+### `stages:` (optional)
 
 A list of [stages](/references/stages/) that are executed before the build of the final image. This is useful for compiling programs from source without polluting the final bootable image.
 

--- a/src/content/docs/reference/recipe.mdx
+++ b/src/content/docs/reference/recipe.mdx
@@ -70,7 +70,7 @@ A list of [stages](/references/stages/) that are executed before the build of th
 ```yaml
 stages:
   - name: bluebuild
-    from: rust:1.77
+    from: docker.io/library/rust:1.77
     modules: # same as the top-level modules key, but executed in the custom stage
       - type: script
         no-cache: true

--- a/src/content/docs/reference/recipe.mdx
+++ b/src/content/docs/reference/recipe.mdx
@@ -63,7 +63,7 @@ image-version: 40
 
 ### `stages:`
 
-A list of [stages](/references/stages/) that is executed outside of the final image. This is useful for compiling programs from source without polluting the final bootable image.
+A list of [stages](/references/stages/) that are executed before the build of the final image. This is useful for compiling programs from source without polluting the final bootable image.
 
 #### Example:
 

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -36,7 +36,7 @@ Contributions to increase the size of this list is [welcome](https://github.com/
 ```yaml
 stages:
 - name: ubuntu-test
-  from: ubuntu:22.04
+  from: docker.io/library/ubuntu:22.04
   modules:
   - type: files
     files:

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -20,7 +20,7 @@ At this time, the following distributions are supported:
 - Fedora
 - Alpine
 
-Contributions to increase the size of this list is [welcome](https://github.com/blue-build/cli)!
+Contributions to increase the size of this list is [welcome](https://github.com/blue-build/cli/blob/main/scripts/setup.sh)!
 
 ## Syntax
 

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -24,14 +24,23 @@ Contributions to increase the size of this list is [welcome](https://github.com/
 
 ## Syntax
 
-- **Required**
-  - `from` - The full image ref (image name + tag). This will be set in the `FROM` statement of the stage.
-  - `name` - The name of the stage. This is used when referencing the stage when using the `from:` property in the `copy` [module](/reference/modules/copy/).
-  - `modules` - The list of modules to execute. The exact same syntax used by the main recipe `modules:` property.
-- **Optional**
-  -  `shell` - Allows a user to pass in an array of strings that are passed directly into the [`SHELL` instruction](https://docs.docker.com/reference/dockerfile/#shell).
+### `from:`
 
-### Example
+The full image ref (image name + tag). This will be set in the `FROM` statement of the stage.
+
+### `name:`
+
+The name of the stage. This is used when referencing the stage when using the `from:` property in the `copy` [module](/reference/modules/copy/).
+
+### `modules:`
+
+The list of modules to execute. The exact same syntax used by the main recipe `modules:` property.
+
+### `shell:` (optional)
+
+Allows a user to pass in an array of strings that are passed directly into the [`SHELL` instruction](https://docs.docker.com/reference/dockerfile/#shell).
+
+## Example
 
 ```yaml
 stages:

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -34,7 +34,7 @@ The name of the stage. This is used when referencing the stage when using the `f
 
 ### `modules:`
 
-The list of modules to execute. The exact same syntax used by the main recipe `modules:` property.
+The list of modules to execute. The exact same syntax used by the main recipe [`modules:`](/reference/module/) property.
 
 ### `shell:` (optional)
 
@@ -43,22 +43,28 @@ Allows a user to pass in an array of strings that are passed directly into the [
 ## Example
 
 ```yaml
+name: custom-image
+base-image: ghcr.io/ublue-os/silverblue
+image-version: 40
+description: Stages example
 stages:
-- name: ubuntu-test
-  from: docker.io/library/ubuntu:22.04
-  modules:
-  - type: files
-    files:
-    - usr: /usr
-  - type: script
-    scripts:
-    - example.sh
-    snippets:
-    - echo "test" > /test.txt
-  - type: test-module
-  - type: containerfile
-    containerfiles:
-    - labels
-    snippets:
-    - RUN echo "This is a snippet"
+  - name: helix
+    from: docker.io/library/rust
+    modules:
+      - type: script
+        snippets:
+          - apt-get update && apt-get install -y git # Install git
+          - git clone https://github.com/helix-editor/helix.git # Clone the helix repo
+          - cd helix && RUSTFLAGS="-C target-feature=-crt-static" cargo install --path helix-term # Use cargo to install
+          - mkdir -p /out/ && mv $CARGO_HOME/bin/hx /out/hx && mv runtime /out/ # Move bin and runtime
+modules:
+  # Copy the bin and runtime from the `helix` stage
+  - type: copy
+    from: helix
+    src: /out/hx
+    dest: /usr/bin/
+  - type: copy
+    from: helix
+    src: /out/runtime
+    dest: /usr/lib64/helix/
 ```

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -36,7 +36,7 @@ Contributions to increase the size of this list is [welcome](https://github.com/
 ```yaml
 stages:
 - name: ubuntu-test
-  from: ubuntu
+  from: ubuntu:22.04
   modules:
   - type: files
     files:

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -1,0 +1,55 @@
+---
+title: Stages
+description: A stage is a separate image build flow executed in parallel with the main build.
+---
+
+:::note
+This feature is currently only available when using `use_unstable_cli` option in the [GHA](/reference/github-action/)
+:::
+
+This property will allow users to define a list of Containerfile stages each with their own modules. Stages can be used to compile programs, perform parallel operations, and copy the results into the final image without contaminating the final image.
+
+## Module Support
+
+Currently the only modules that work out-of-the-box are `copy`, `script`, `files`, and `containerfile`. Other modules are dependent on the programs installed on the image. In order to better support some of our essential modules, a setup script is ran at the start of each stage that is not `scratch`. This script will install `curl`, `wget`, `bash`, and `grep` and use the package manager for the detected distributions.
+
+At this time, the following distributions are supported:
+
+- Debian
+- Ubuntu
+- Fedora
+- Alpine
+
+Contributions to increase the size of this list is [welcome](https://github.com/blue-build/cli)!
+
+## Syntax
+
+- **Required**
+  - `from` - The full image ref (image name + tag). This will be set in the `FROM` statement of the stage.
+  - `name` - The name of the stage. This is used when referencing the stage when using the `from:` property in the `copy` [module](/reference/modules/copy/).
+  - `modules` - The list of modules to execute. The exact same syntax used by the main recipe `modules:` property.
+- **Optional**
+  -  `shell` - Allows a user to pass in an array of strings that are passed directly into the [`SHELL` instruction](https://docs.docker.com/reference/dockerfile/#shell).
+
+### Example
+
+```yaml
+stages:
+- name: ubuntu-test
+  from: ubuntu
+  modules:
+  - type: files
+    files:
+    - usr: /usr
+  - type: script
+    scripts:
+    - example.sh
+    snippets:
+    - echo "test" > /test.txt
+  - type: test-module
+  - type: containerfile
+    containerfiles:
+    - labels
+    snippets:
+    - RUN echo "This is a snippet"
+```

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -4,7 +4,7 @@ description: A stage is a separate image build flow executed in parallel with th
 ---
 
 :::note
-This feature is currently only available when using `use_unstable_cli` option in the [GHA](/reference/github-action/)
+This feature is experimental and currently only available when using `use_unstable_cli` option in the [GitHub Action](/reference/github-action/) or using the `stages` feature when compiling.
 :::
 
 This property will allow users to define a list of Containerfile stages each with their own modules. Stages can be used to compile programs, perform parallel operations, and copy the results into the final image without contaminating the final image.

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -20,7 +20,7 @@ At this time, the following distributions are supported:
 - Fedora
 - Alpine
 
-Contributions to increase the size of this list is [welcome](https://github.com/blue-build/cli/blob/main/scripts/setup.sh)!
+Other distributions can be used, but the necessary packages won't be installed automatically. Contributions to increase the size of this list is [welcome](https://github.com/blue-build/cli/blob/main/scripts/setup.sh)!
 
 ## Syntax
 

--- a/src/content/docs/reference/stages.mdx
+++ b/src/content/docs/reference/stages.mdx
@@ -44,7 +44,7 @@ Allows a user to pass in an array of strings that are passed directly into the [
 
 ```yaml
 name: custom-image
-base-image: ghcr.io/ublue-os/silverblue
+base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 40
 description: Stages example
 stages:


### PR DESCRIPTION
This is in relation to the new [stages](https://github.com/blue-build/cli/pull/173) feature being added.

Closes #56 