### PR TITLE
docs(module): Document `get_json_array` instead of now depreciated `g…

### DIFF
--- a/src/content/docs/reference/module.mdx
+++ b/src/content/docs/reference/module.mdx
@@ -74,12 +74,18 @@ Environment variable containing the URL of the OCI image used as the base.
 
 Environment variable containing the major version of running operating system. The value is gathered from the `VERSION_ID` in `/etc/os-release`.
 
-### `get_yaml_array`
+### `get_json_array`
 
 Bash function that helps with reading arrays from the module's configuration.
 
 ```bash frame="none"
-get_yaml_array OUTPUT_VAR_NAME '.yq.key.to.array[]' "$1"
+get_json_array OUTPUT_VAR_NAME '.yq.key.to.array[]' "${1}"
+```
+
+or less readable, but more safe command for extracting array values:
+
+```bash frame="none"
+get_json_array OUTPUT_VAR_NAME '.["yq"].["key"].["to"].["array"][]' "${1}"
 ```
 
 ## `module.yml`


### PR DESCRIPTION
…et_yaml_array`