### PR TITLE
fix: don't have env and secrets in every module ref page

### DIFF
--- a/src/content/docs/reference/module.mdx
+++ b/src/content/docs/reference/module.mdx
@@ -25,6 +25,14 @@ The URL of the module repository (an OCI image) to pull the module from. If left
 
 When set to `true`, the module is run regardless if previous layers in the build have been cached. This is useful in [stages](/reference/stages) where the goal is to build the latest version of a program from a git repository. Otherwise, the module wouldn't run again unless previous layers were also re-ran.
 
+### `env:` (optional)
+
+A list of environment variables to set when running the module. These variables are available to the module's script and can be used to customize its behavior.
+
+### `secrets:` (optional)
+
+A list of secrets to mount when running the module. These secrets are available to the module's script and can be used only by it.
+
 ## How modules are launched
 
 A module added into an image's configuration is turned into a `RUN`-statement that launches the module with a JSON version of its configuration in the generated Containerfile (or an equivalent dynamic bash command if using the legacy template).

--- a/src/plugins/moduleReferencePlugin.ts
+++ b/src/plugins/moduleReferencePlugin.ts
@@ -105,7 +105,7 @@ async function generateReferencePage(
             version.examples ?? [],
             schema as { properties: object; required: string[] },
             `:::note
-This documentation page is for the latest version (${version.version}) of this module.  
+This documentation page is for the latest version (${version.version}) of this module.
 All available versions: ${module.versions.map((v) => `[${v.version}](${v.version})`).join(", ")}.
 :::
 ` + readme,
@@ -205,7 +205,13 @@ function generateOptionReference(schema: {
     let out = "";
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     for (const [key, value] of Object.entries(properties)) {
-      if (key === "type" || key === "no-cache") continue;
+      if (
+        key === "type" ||
+        key === "no-cache" ||
+        key === "env" ||
+        key === "secrets"
+      )
+        continue;
       const object =
         value.$ref !== undefined
           ? schema.$defs[


### PR DESCRIPTION
#91

Need to expand with syntax example for `env` and explanation of `secrets` (optionally on a separate page).