### PR TITLE
Update universal-blue.mdx reference to dnf module

### DIFF
--- a/src/content/docs/learn/universal-blue.mdx
+++ b/src/content/docs/learn/universal-blue.mdx
@@ -56,7 +56,7 @@ If you have already installed an atomic Fedora version or something derivative s
 
 ## Essential modules
 
--   To install packages, use [`rpm-ostree`](/reference/modules/rpm-ostree/).
+-   To install packages, use the [`dnf`](/reference/modules/dnf/) module.
 
 ## Custom [`just`](https://just.systems/) recipes
 


### PR DESCRIPTION
As I understand it, the way to install is now the dnf module and no longer rpm-ostree. (https://blue-build.org/blog/dnf-module/)
So this should also be changed in the docs.