### PR TITLE
Fix(Footer): tidy up the footer by disabling floating menu

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,10 +11,7 @@ const isFrontPage = Astro.url.pathname === "/";
         <>
             <hr class="mt-32" />
             <footer class="absolute left-0 h-16 w-screen bg-gradient-to-b from-accent-300/50 to-transparent dark:from-gray-600/50">
-                <div
-                    class="absolute flex h-16 -translate-y-3 translate-x-3 flex-row items-center gap-4 bg-white px-8 outline outline-1 outline-gray-900
-            dark:bg-gray-900 dark:outline-gray-200 sm:-translate-y-6 sm:translate-x-6 sm:gap-8 sm:px-16"
-                >
+                <div class="flex h-16 flex-row items-center justify-center md:justify-start gap-4 sm:gap-8 px-8">
                     <NavLinks {...Astro.locals.starlightRoute} />
                 </div>
             </footer>


### PR DESCRIPTION
Theres a floating menu on footer which is bit distracting on large screen. its would be better if menu placed inside footer container and centered on small screen.
<img width="1366" height="653" alt="Screenshot From 2026-02-07 19-11-49" src="https://github.com/user-attachments/assets/64024950-67da-4cdf-a760-3150df7ac0de" />
<img width="496" height="652" alt="Screenshot From 2026-02-07 19-12-18" src="https://github.com/user-attachments/assets/adc56298-52bf-4e77-a5ab-dbe05df06670" />
